### PR TITLE
Fix nav overlap on medium screens

### DIFF
--- a/app/styles/components/navigation.css
+++ b/app/styles/components/navigation.css
@@ -70,7 +70,7 @@
 }
 
 /* Responsive styles for navigation */
-@media (max-width: 900px) {
+@media (max-width: 985px) {
   .side-nav {
     display: none !important;
   }
@@ -88,7 +88,7 @@
   }
 }
 
-@media (min-width: 641px) and (max-width: 900px) {
+@media (min-width: 641px) and (max-width: 985px) {
   .hamburger-btn {
     width: 48px !important;
     height: 48px !important;


### PR DESCRIPTION
## Summary
- extend mobile navigation breakpoint so the hamburger menu shows up to 985px

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6855e50081c08326bad9b6f8ac04508d