### PR TITLE
Ensure LinkedIn icon aligns before text

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -600,10 +600,9 @@ const Portfolio = () => {
                   href="https://www.linkedin.com/in/max-burleigh/"
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="flex items-center gap-2 mt-2 text-blue-500 hover:text-blue-700 transition-colors font-medium"
-                  style={{ width: "fit-content" }}
+                  className="mt-2 text-blue-500 hover:text-blue-700 transition-colors font-medium space-x-2"
                 >
-                  <SiLinkedin style={{ width: 22, height: 22 }} />
+                  <SiLinkedin className="w-[22px] h-[22px] flex-shrink-0" />
                   <span>LinkedIn</span>
                 </a>
               </div>

--- a/app/styles/components/project-card.css
+++ b/app/styles/components/project-card.css
@@ -419,7 +419,8 @@
 /* Animated underline effect for links inside contact card */
 .contact-card a {
   position: relative;
-  display: inline-block;
+  display: inline-flex;
+  align-items: center;
 }
 
 .contact-card a::after {


### PR DESCRIPTION
## Summary
- update contact link CSS to use inline-flex so LinkedIn icon stays beside text
- remove redundant flex classes from LinkedIn anchor

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689ac944ddcc8326831118086ce8a538