### PR TITLE
Fix LinkedIn icon spacing

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -600,9 +600,9 @@ const Portfolio = () => {
                   href="https://www.linkedin.com/in/max-burleigh/"
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="inline-flex items-center text-blue-500 hover:text-blue-700 transition-colors font-medium space-x-2"
+                  className="inline-flex items-center text-blue-500 hover:text-blue-700 transition-colors font-medium"
                 >
-                  <SiLinkedin className="w-[22px] h-[22px] flex-shrink-0" />
+                  <SiLinkedin className="w-[22px] h-[22px] flex-shrink-0 mr-2" />
                   <span>LinkedIn</span>
                 </a>
               </div>


### PR DESCRIPTION
## Summary
- remove space-x-2 class from LinkedIn link
- add right margin to LinkedIn icon for proper horizontal layout

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a3d4dac4788326ac02b6127ffb17ea