### PR TITLE
Match portfolio image border radius with card

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -448,6 +448,7 @@ const Portfolio = () => {
                   style={{
                     objectFit: "cover",
                     transform: "translateZ(20px)",
+                    borderRadius: "0.5rem",
                   }}
                   priority
                 />


### PR DESCRIPTION
## Summary
- Add matching 0.5rem border radius to portfolio portrait image so it aligns with the card container

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a54a1df2c08326a0ab01dc33550fee